### PR TITLE
feat: update index redirect logic

### DIFF
--- a/packages/web/src/routes/(marketing)/index.tsx
+++ b/packages/web/src/routes/(marketing)/index.tsx
@@ -1,9 +1,15 @@
-import { createFileRoute, Navigate } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/(marketing)/')({
-  component: RouteComponent,
-});
+  beforeLoad: async () => {
+    const { getRequest } = await import('@tanstack/react-start/server');
+    const { auth } = await import('@lax-db/core/auth');
+    const request = getRequest();
+    const { headers } = request;
 
-function RouteComponent() {
-  return <Navigate to="/login" />;
-}
+    const session = await auth.api.getSession({ headers });
+
+    if (!session) throw redirect({ to: '/login' });
+    // throw redirect({ to: '/redirect' });
+  },
+});


### PR DESCRIPTION
### TL;DR

Replaced client-side navigation redirect with server-side redirect in the marketing route.

### What changed?

- Removed the `RouteComponent` that used `<Navigate to="/login" />` for client-side redirection
- Implemented a `beforeLoad` hook that performs server-side authentication check
- Added logic to redirect unauthenticated users to the login page using `redirect` from TanStack Router
- Imported necessary authentication utilities from `@lax-db/core/auth`

### How to test?

1. Visit the marketing route (`/`) while not logged in - you should be redirected to `/login`
2. Log in and visit the marketing route - you should not be redirected
3. Verify that the redirection happens server-side by checking network requests

### Why make this change?

Server-side redirects provide better security and user experience by checking authentication status before rendering any components. This prevents momentary flashes of protected content and reduces client-side processing by handling the redirect logic on the server.