### PR TITLE
feat: add some logging middleware

### DIFF
--- a/packages/web/src/lib/middleware.ts
+++ b/packages/web/src/lib/middleware.ts
@@ -29,3 +29,43 @@ export const authMiddleware = createMiddleware({
     },
   });
 });
+
+const preLogMiddleware = createMiddleware({ type: 'function' })
+  .client(async (ctx) => {
+    const clientTime = new Date();
+
+    return ctx.next({
+      context: {
+        clientTime,
+      },
+      sendContext: {
+        clientTime,
+      },
+    });
+  })
+  .server(async (ctx) => {
+    const serverTime = new Date();
+
+    return ctx.next({
+      sendContext: {
+        serverTime,
+        durationToServer:
+          serverTime.getTime() - ctx.context.clientTime.getTime(),
+      },
+    });
+  });
+
+export const logMiddleware = createMiddleware({ type: 'function' })
+  .middleware([preLogMiddleware])
+  .client(async (ctx) => {
+    const res = await ctx.next();
+
+    const now = new Date();
+    console.log('Client Req/Res:', {
+      duration: now.getTime() - res.context.clientTime.getTime(),
+      durationToServer: res.context.durationToServer,
+      durationFromServer: now.getTime() - res.context.serverTime.getTime(),
+    });
+
+    return res;
+  });


### PR DESCRIPTION
### TL;DR

Added logging middleware to track request/response timing metrics.

### What changed?

- Created a new `preLogMiddleware` that captures client and server timestamps
- Implemented `logMiddleware` that uses the timestamps to calculate and log:
  - Total request/response duration
  - Time taken to reach the server
  - Time taken for the response to return from the server

### How to test?

1. Make any API request from the client
2. Check the console logs for timing metrics in the format:
   ```
   Client Req/Res: {
     duration: [total time in ms],
     durationToServer: [time to server in ms],
     durationFromServer: [time from server in ms]
   }
   ```

### Why make this change?

This middleware provides valuable performance metrics that can help identify bottlenecks in client-server communication. By tracking the time spent in different parts of the request lifecycle, we can better understand and optimize application performance.