### PR TITLE
patch: sst-env.d.ts changes with new db setup

### DIFF
--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -18,7 +18,7 @@ declare module 'sst' {
       host: string;
       password: string;
       port: number;
-      type: 'sst.aws.Postgres';
+      type: 'sst.sst.Linkable';
       username: string;
     };
     DatabaseMigrator: {
@@ -35,6 +35,18 @@ declare module 'sst' {
       value: string;
     };
     GoogleAuthClientSecret: {
+      type: 'sst.sst.Secret';
+      value: string;
+    };
+    PlanetScaleHost: {
+      type: 'sst.sst.Secret';
+      value: string;
+    };
+    PlanetScalePassword: {
+      type: 'sst.sst.Secret';
+      value: string;
+    };
+    PlanetScaleUsername: {
       type: 'sst.sst.Secret';
       value: string;
     };


### PR DESCRIPTION
### TL;DR

Updated database configuration to support PlanetScale integration.

### What changed?

- Changed the `Database` type from `sst.aws.Postgres` to `sst.sst.Linkable` to make it more generic
- Added three new environment variables for PlanetScale configuration:
  - `PlanetScaleHost`
  - `PlanetScalePassword`
  - `PlanetScaleUsername`

### How to test?

1. Verify that existing Postgres connections still work with the updated type
2. Test PlanetScale connection using the new environment variables
3. Ensure that applications can connect to PlanetScale using the new configuration

### Why make this change?

This change enables the application to connect to PlanetScale databases in addition to AWS Postgres. By making the database type more generic (`Linkable` instead of `Postgres`-specific) and adding PlanetScale-specific configuration variables, we can support multiple database providers, giving users more flexibility in their database choices.